### PR TITLE
Changing cryptography version to minimum

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ requests==2.14.2
 texttable==1.4.0
 configparser==3.5.0
 future==0.16.0
-cryptography==2.1.4
+cryptography>=2.1.4


### PR DESCRIPTION
Fixes incompatibility with pyopenssl 19.0.0