### PR TITLE
Moving parser def into class

### DIFF
--- a/bin/config.py
+++ b/bin/config.py
@@ -31,10 +31,9 @@ else:
 
 logger = logging.getLogger(__name__)
 
-parser = argparse.ArgumentParser(description='Process command line options.')
-
-
 class EdgeGridConfig():
+
+    parser = argparse.ArgumentParser(description='Process command line options.')
 
     def __init__(self, config_values, configuration, flags=None):
 


### PR DESCRIPTION
Fixes below error.

AttributeError: 'EdgeGridConfig' object has no attribute 'parser'